### PR TITLE
Minor fix: Copy-paste issue in the list of used baselineLD annotations

### DIFF
--- a/sLDSC/70_baselineLD_annotations.txt
+++ b/sLDSC/70_baselineLD_annotations.txt
@@ -21,7 +21,8 @@ H3K27ac_PGC2
 H3K27ac_PGC2.extend.500
 H3K4me1_peaks_Trynka
 H3K4me1_Trynka
-H3K4me1_Trynka.extend.50H3K4me3_peaks_Trynka
+H3K4me1_Trynka.extend.500
+H3K4me3_peaks_Trynka
 H3K4me3_Trynka
 H3K4me3_Trynka.extend.500
 H3K9ac_peaks_Trynka


### PR DESCRIPTION
The file mentions an annotation named "H3K4me1_Trynka.extend.50H3K4me3_peaks_Trynka". There is no such annotation in baselineLD, but there are two annotations called "H3K4me1_Trynka.extend.500" and "H3K4me3_peaks_Trynka" that go one after another in baselineLD list.  
I think that a glitch happened when the list of used annotations was copy-pasted to this repo after the analysis was done, causing a merger of the two sequential lines. It seems unlikely to me that this has affected the original analysis.  
This PR fixes this merger (and also changes the name of the file accordingly from 69 to 70 annotations).